### PR TITLE
Creon 객체 생성시 옵셔널한 로그인 인자 받음

### DIFF
--- a/creon/core.py
+++ b/creon/core.py
@@ -60,16 +60,16 @@ class Creon:
     __chart__ = None
     __logger__ = Logger(__name__)
 
-    def __init__(self):
+    def __init__(self, username: str = '', password: str = '', cert_password: str = '', path: str = ''):
         if not windll.shell32.IsUserAnAdmin():
             raise PermissionError("Run as administrator")
 
         if 'CpStart.exe' not in [p.name() for p in process_iter()]:
             run_creon_plus(
-                environ.get('CREON_USERNAME', ''),
-                environ.get('CREON_PASSWORD', ''),
-                environ.get('CREON_CERTIFICATION_PASSWORD', ''),
-                environ.get('CREON_PATH', '')
+                username or environ.get('CREON_USERNAME', ''),
+                password or environ.get('CREON_PASSWORD', ''),
+                cert_password or environ.get('CREON_CERTIFICATION_PASSWORD', ''),
+                path or environ.get('CREON_PATH', '')
             )
 
     @property


### PR DESCRIPTION
안녕하세요.

Creon 객체 생성시 크레온 로그인 정보 등을 환경변수로만 받는데 이것을 옵셔널하게 받을 수 있도록 수정하였습니다.