### PR TITLE
64-bit python 구동 시 에러 처리

### DIFF
--- a/creon/core.py
+++ b/creon/core.py
@@ -1,3 +1,4 @@
+import sys
 from calendar import Calendar
 from ctypes import windll
 from datetime import datetime, timedelta
@@ -63,6 +64,11 @@ class Creon:
     def __init__(self, username: str = '', password: str = '', cert_password: str = '', path: str = ''):
         if not windll.shell32.IsUserAnAdmin():
             raise PermissionError("Run as administrator")
+
+        is_64bit = sys.maxsize > 2**32
+
+        if is_64bit:
+            raise Exception('Run with 32-bit Python.')
 
         if 'CpStart.exe' not in [p.name() for p in process_iter()]:
             run_creon_plus(

--- a/creon/core.py
+++ b/creon/core.py
@@ -68,7 +68,7 @@ class Creon:
         is_64bit = sys.maxsize > 2**32
 
         if is_64bit:
-            raise Exception('Run with 32-bit Python.')
+            raise RuntimeError('Run with 32-bit Python.')
 
         if 'CpStart.exe' not in [p.name() for p in process_iter()]:
             run_creon_plus(


### PR DESCRIPTION
어떤 내장 예외 클래스 붙일까 고민하다 일단 Exception 으로 했는데 빌트인 말고 직접 만들어 쓰는게 좋을까여